### PR TITLE
Make `federated_id` and `email` optional

### DIFF
--- a/src/api/user.rs
+++ b/src/api/user.rs
@@ -160,8 +160,8 @@ pub struct UpdateUser {
 #[serde(rename_all = "camelCase")]
 pub struct ProviderUserInfo {
     pub provider_id: String,
-    pub federated_id: String,
-    pub email: String,
+    pub federated_id: Option<String>,
+    pub email: Option<String>,
     pub raw_id: String,
 }
 


### PR DESCRIPTION
Since `email` is optional if the provider is "phone" or a federated identity provider like Facebook and the same goes for `federated_id` with phone auth. Therefore, these fields should be optional. Valid authentication is failing because this deserialization is failing.